### PR TITLE
Fix display_modpack exploit

### DIFF
--- a/mods/display_modpack/font_api/fontform.lua
+++ b/mods/display_modpack/font_api/fontform.lua
@@ -51,15 +51,9 @@ local function show_node_formspec(playername, pos)
 	fs = fs:gsub("context", nodemeta)
 
 	-- Change all ${} to their corresponding metadata values
-	local s, e
-	repeat
-		s, e = fs:find('%${.*}')
-		if s and e then
-			fs = fs:sub(1, s-1)..
-				minetest.formspec_escape(meta:get_string(fs:sub(s+2,e-1)))..
-				fs:sub(e+1)
-		end
-	until s == nil
+	fs = fs:gsub("([^\\])${(.-)}", function(prefix, key)
+		return prefix .. minetest.formspec_escape(meta:get_string(key))
+	end)
 
 	local context = get_context(playername)
 	context.node_pos = pos


### PR DESCRIPTION
This is a backport of https://github.com/mt-mods/display_modpack/pull/8 (and the couple of commits before that) to the display_modpack version used here. Malicious users can cause the server to lock up without this fix.