### PR TITLE
Fix jobs messages

### DIFF
--- a/mods/jobs/gui.lua
+++ b/mods/jobs/gui.lua
@@ -104,6 +104,7 @@ jobs.purge_unread()--do some culling every startup
 local function add_unread(name, jobname, channel)
 	if not unread_msg[name] then unread_msg[name] = {} end
 	if not unread_msg[name][jobname] then unread_msg[name][jobname] = {} end
+	if unread_msg[name][jobname] == true then return end -- stops function when whole table is true 
 	if not unread_msg[name][jobname][channel] and unread_msg[name][jobname] ~= true then
 		unread_msg[name][jobname][channel] = true
 		local isfull = 0


### PR DESCRIPTION
When writing a new message in a job chat while for one or more employee of that job there are unread messages in all channels that job (unread_msg[name][jobname] = true), it tried to compare a table to a boolean. Now it catches that and ends the function (since it doesnt need to add another unread message if the table is already true)