### PR TITLE
currency:shop:  Fix metadata exploit

### DIFF
--- a/mods/currency/shop.lua
+++ b/mods/currency/shop.lua
@@ -225,8 +225,8 @@ minetest.register_on_player_receive_fields(function(sender, formname, fields)
 			end
 			if can_exchange then
 				for i, item in pairs(wants) do
-					minv:remove_item("customer_gives",item)
-					minv:add_item("customers_gave",item)
+					local cust_gave_item = minv:remove_item("customer_gives",item)
+					minv:add_item("customers_gave",cust_gave_item)
 				end
 				for i, item in pairs(gives) do
 					minv:remove_item("stock",item)

--- a/mods/currency/shop.lua
+++ b/mods/currency/shop.lua
@@ -229,8 +229,8 @@ minetest.register_on_player_receive_fields(function(sender, formname, fields)
 					minv:add_item("customers_gave",cust_gave_item)
 				end
 				for i, item in pairs(gives) do
-					minv:remove_item("stock",item)
-					minv:add_item("customer_gets",item)
+					local stock_item = minv:remove_item("stock",item)
+					minv:add_item("customer_gets",stock_item)
 				end
 				minetest.chat_send_player(name,"Exchanged!")
 				local counter = meta:get_string("counter")


### PR DESCRIPTION
Shops could be used to duplicate metadata from one item to another by placing the item with source metadata (e.g. tool with zero wear) in the `owner_wants` inventory, and placing items in `customer_gives` inventory (e.g. worn tools) and clicking "Exchange", which would copy the tool with zero wear into the `customers_gave` inventory.