### PR TITLE
Make IRC not crash out of the box if not configured

### DIFF
--- a/mods/irc/init.lua
+++ b/mods/irc/init.lua
@@ -7,9 +7,10 @@ local modpath = minetest.get_modpath(minetest.get_current_modname())
 local ie, req_ie = _G, minetest.request_insecure_environment
 if req_ie then ie = req_ie() end
 if not ie then
-	error("The IRC mod requires access to insecure functions in order "..
+	minetest.log("warning", "The IRC mod requires access to insecure functions in order "..
 		"to work.  Please add the irc mod to your secure.trusted_mods "..
 		"setting or disable the irc mod.")
+	return -- just disable the mod
 end
 
 ie.package.path =
@@ -28,6 +29,12 @@ if not rawget(_G, "jit") and package.config:sub(1, 1) == "/" then
 			";/usr/share/lua/5.1/?/init.lua"
 	ie.package.cpath = ie.package.cpath..
 			";/usr/lib/lua/5.1/?.so"
+end
+
+local status, err = pcall(ie.require, "socket")
+if not status then
+	minetest.log("warning", "The IRC mod can not find luasocket: " .. err)
+	return
 end
 
 -- Temporarily set require so that LuaIRC can access it

--- a/mods/irc_commands/init.lua
+++ b/mods/irc_commands/init.lua
@@ -1,3 +1,7 @@
+if not minetest.global_exists("irc") then
+	minetest.log("warning", "IRC is disabled, hence IRC commands are disabled too.")
+	return
+end
 
 local irc_users = {}
 


### PR DESCRIPTION
Instead warn. Slightly hacky but overall useful.