### PR TITLE
Add Moon Phases Mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "mods/alpha_workaround_minus"]
 	path = mods/alpha_workaround_minus
 	url = https://codeberg.org/appgurueu/alpha_workaround_minus.git
+[submodule "mods/ecliptic_cycle"]
+	path = mods/ecliptic_cycle
+	url = https://github.com/Extex101/ecliptic_cycle.git


### PR DESCRIPTION
# Moon phases mod.
  - Due to engine limitations, the moon is eternally locked at 180 degrees from the sun.
  - A configuration that would produce a constant Lunar Eclipse.
  - This mod takes that idea and makes moon phases out of it. 
  - The moon rocks from side-to-side, in-and-out of the umbra of the earth.
  - There are 30 phases, and some rare, color events.
![Doom](https://raw.githubusercontent.com/Extex101/ecliptic_cycle/refs/heads/main/screenshot.png) ![The Dance of the Pale](https://cdn.discordapp.com/attachments/780505995323375637/1360025411383328878/ecliptic_cycle_dance_of_the_pale.gif?ex=67f99dde&is=67f84c5e&hm=9260999ba1b20690918a22ba94858ce19367bf1bf9b6a1eddff19132ff019871)
![Blackmore's Night](https://cdn.discordapp.com/attachments/780505995323375637/1360040113945448459/ezgif-72bf752e238357.png?ex=67f9ab8f&is=67f85a0f&hm=bd0d7e4e81f21c27a7bd296bc68845f4e400900d3fb4c3d7070ff558fe763379)

# Why add it?
- Immersion and aesthetics.

- Testimonials from CS players in support of the mod:
> nom nom nom nom - Fatalist Error
> what horrors did you conjure? - Talos
> niice - NoahTheKiyatcha

# How Intrusive is it?

```
Once every 10 seconds (adjustable) 
	Get the in-game time, 
	if it is daytime it will:
		get the current day_count
		Compare current moon phase to the calculation based on day_count
		If the current day's phase is greater than the set phase:
			set the phase forward		
			update the moon for all players.

Every time a player joins it will
	Update the player's moon to match everyone else.
```

So once every day, the players will be updated.
Every time a player joins, their moon is updated.

So it shouldn't contribute to the lag.